### PR TITLE
0.38.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.38.0
+
+This version introduces a new configuration property: `textWidthMeasurer`. You can now set a custom function to measure the width of text in the designer. Measuring text width is necessary to calculate the layout of the designer components. By default, the designer uses the `getBBox()` method to measure text width. This method is universal and always works, but unfortunately, it is not the fastest option. You can now provide your own implementation, for example, by using the `CanvasRenderingContext2D.measureText()` method.
+
+Added support for Angular 22.
+
 # 0.37.4
 
 This version adds a new event: `onIsDraggingChanged`. This event is triggered when the dragging state of the designer changes. Additionally, the `Designer` class now includes the `isDragging()` method, which allows you to check if the designer is currently in a dragging state.

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ Add the below code to your head section in HTML document.
 ```html
 <head>
   ...
-  <link href="https://cdn.jsdelivr.net/npm/sequential-workflow-designer@0.37.4/css/designer.css" rel="stylesheet" />
-  <link href="https://cdn.jsdelivr.net/npm/sequential-workflow-designer@0.37.4/css/designer-light.css" rel="stylesheet" />
-  <link href="https://cdn.jsdelivr.net/npm/sequential-workflow-designer@0.37.4/css/designer-dark.css" rel="stylesheet" />
-  <script src="https://cdn.jsdelivr.net/npm/sequential-workflow-designer@0.37.4/dist/index.umd.js"></script>
+  <link href="https://cdn.jsdelivr.net/npm/sequential-workflow-designer@0.38.0/css/designer.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/sequential-workflow-designer@0.38.0/css/designer-light.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/sequential-workflow-designer@0.38.0/css/designer-dark.css" rel="stylesheet" />
+  <script src="https://cdn.jsdelivr.net/npm/sequential-workflow-designer@0.38.0/dist/index.umd.js"></script>
 </head>
 ```
 

--- a/angular/designer/package.json
+++ b/angular/designer/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "sequential-workflow-designer-angular",
 	"description": "Angular wrapper for Sequential Workflow Designer component.",
-	"version": "0.37.4",
+	"version": "0.38.0",
 	"author": {
 		"name": "NoCode JS",
 		"url": "https://nocode-js.com/"
@@ -13,9 +13,9 @@
 		"url": "https://github.com/nocode-js/sequential-workflow-designer.git"
 	},
 	"peerDependencies": {
-		"@angular/common": "12 - 21",
-		"@angular/core": "12 - 21",
-		"sequential-workflow-designer": "^0.37.4"
+		"@angular/common": "12 - 22",
+		"@angular/core": "12 - 22",
+		"sequential-workflow-designer": "^0.38.0"
 	},
 	"dependencies": {
 		"tslib": "^2.3.0"

--- a/demos/angular-app/package.json
+++ b/demos/angular-app/package.json
@@ -26,8 +26,8 @@
 		"@angular/platform-browser-dynamic": "^17.3.9",
 		"@angular/router": "^17.3.9",
 		"rxjs": "~7.8.0",
-		"sequential-workflow-designer": "^0.37.4",
-		"sequential-workflow-designer-angular": "^0.37.4",
+		"sequential-workflow-designer": "^0.38.0",
+		"sequential-workflow-designer-angular": "^0.38.0",
 		"tslib": "^2.3.0",
 		"zone.js": "~0.14.6"
 	},

--- a/demos/angular-app/yarn.lock
+++ b/demos/angular-app/yarn.lock
@@ -6744,17 +6744,17 @@ send@0.18.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-sequential-workflow-designer-angular@^0.37.4:
-  version "0.37.4"
-  resolved "https://registry.yarnpkg.com/sequential-workflow-designer-angular/-/sequential-workflow-designer-angular-0.37.4.tgz#453290f1ec02fa5d22a75a044713a5c33bd6d27c"
-  integrity sha512-Q4rQi2vhDQK/wVkmTBNX6ldLkT8GN9qdyYTnvgsGVjtZxcF9qqwToLeMoAXidDP0qjvd0In27K6TDMfjgMsYyw==
+sequential-workflow-designer-angular@^0.38.0:
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/sequential-workflow-designer-angular/-/sequential-workflow-designer-angular-0.38.0.tgz#0adc1e6082068ac53e18e6386851244b6501bc12"
+  integrity sha512-TPD8sJyDvt12WXFTMcqvHfV8xoto6ydLtd0wIMcF/eJ04CcV7VUXZurfMoz9Pc0TLxaD+5GfYTXJ74MSJEBGaQ==
   dependencies:
     tslib "^2.3.0"
 
-sequential-workflow-designer@^0.37.4:
-  version "0.37.4"
-  resolved "https://registry.yarnpkg.com/sequential-workflow-designer/-/sequential-workflow-designer-0.37.4.tgz#6a6abfa56b1cec7e07bc748da448c2f944f185e4"
-  integrity sha512-sjQy7yl265Ei4Pd3uX7CxJ2BICtPA73b3T7hpn1jQGqDlBqHofHw8BZvnM5UB0re5/vAuvsGnhldeAxjprJT7g==
+sequential-workflow-designer@^0.38.0:
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/sequential-workflow-designer/-/sequential-workflow-designer-0.38.0.tgz#3977bfe43e9780b0a69963116397b0dd8902a478"
+  integrity sha512-dqzhyVU5vihzjcUQ5uoIBAMKMI4r5zHvAPSHFZa6C4KWFtdLJIc3+rIdPrxxpMajAsjJpTFVW645C7jd+Rz5jA==
   dependencies:
     sequential-workflow-model "^0.2.0"
 

--- a/demos/react-app/package.json
+++ b/demos/react-app/package.json
@@ -6,8 +6,8 @@
 	"dependencies": {
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"sequential-workflow-designer": "^0.37.4",
-		"sequential-workflow-designer-react": "^0.37.4"
+		"sequential-workflow-designer": "^0.38.0",
+		"sequential-workflow-designer-react": "^0.38.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^29.2.5",

--- a/demos/react-app/src/saveRequiredEditor/ChangeController.tsx
+++ b/demos/react-app/src/saveRequiredEditor/ChangeController.tsx
@@ -8,7 +8,7 @@ export class ChangeController {
 	public set(isChanged: boolean) {
 		if (this.isChanged !== isChanged) {
 			this.isChanged = isChanged;
-			this.onIsChangedChanged.forward(isChanged);
+			this.onIsChangedChanged.emit(isChanged);
 		}
 	}
 }

--- a/demos/svelte-app/package.json
+++ b/demos/svelte-app/package.json
@@ -16,8 +16,8 @@
 		"eslint": "eslint ./src --ext .ts"
 	},
 	"dependencies": {
-		"sequential-workflow-designer": "^0.37.4",
-		"sequential-workflow-designer-svelte": "^0.37.4"
+		"sequential-workflow-designer": "^0.38.0",
+		"sequential-workflow-designer-svelte": "^0.38.0"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-static": "^2.0.3",

--- a/designer/package.json
+++ b/designer/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "sequential-workflow-designer",
 	"description": "Customizable no-code component for building flow-based programming applications.",
-	"version": "0.37.4",
+	"version": "0.38.0",
 	"type": "module",
 	"main": "./lib/esm/index.js",
 	"types": "./lib/index.d.ts",

--- a/designer/src/component-context.ts
+++ b/designer/src/component-context.ts
@@ -1,7 +1,7 @@
 import { DefinitionWalker } from 'sequential-workflow-model';
 import { DefinitionValidator } from './core/definition-validator';
 import { IconProvider } from './core/icon-provider';
-import { DesignerConfiguration, I18n, PreferenceStorage } from './designer-configuration';
+import { DesignerConfiguration, I18n, PreferenceStorage, TextWidthMeasurer } from './designer-configuration';
 import { DesignerState } from './designer-state';
 import { Services } from './services';
 import { StepComponentFactory } from './workspace/step-component-factory';
@@ -17,6 +17,7 @@ export class ComponentContext {
 		definitionWalker: DefinitionWalker,
 		preferenceStorage: PreferenceStorage,
 		i18n: I18n,
+		textWidthMeasurer: TextWidthMeasurer,
 		services: Services
 	): ComponentContext {
 		const validator = new DefinitionValidator(configuration.validator, state);
@@ -32,6 +33,7 @@ export class ComponentContext {
 			services,
 			preferenceStorage,
 			i18n,
+			textWidthMeasurer,
 			state
 		);
 	}
@@ -46,6 +48,7 @@ export class ComponentContext {
 		public readonly services: Services,
 		public readonly preferenceStorage: PreferenceStorage,
 		public readonly i18n: I18n,
+		public readonly textWidthMeasurer: TextWidthMeasurer,
 		private readonly state: DesignerState
 	) {}
 

--- a/designer/src/core/dom.ts
+++ b/designer/src/core/dom.ts
@@ -16,10 +16,11 @@ export class Dom {
 	}
 
 	public static attrs(element: Element, attributes: Attributes) {
-		Object.keys(attributes).forEach(name => {
+		const names = Object.keys(attributes);
+		for (const name in names) {
 			const value = attributes[name];
 			element.setAttribute(name, typeof value === 'string' ? value : value.toString());
-		});
+		}
 	}
 
 	public static element<T extends keyof HTMLElementTagNameMap>(name: T, attributes?: Attributes): HTMLElementTagNameMap[T] {

--- a/designer/src/core/measure-text-width.spec.ts
+++ b/designer/src/core/measure-text-width.spec.ts
@@ -1,0 +1,18 @@
+import { Dom } from './dom';
+import { measureTextWidth } from './measure-text-width';
+
+describe('measureTextWidth', () => {
+	it('returns positive width for visible text', () => {
+		const svg = Dom.svg('svg');
+		const text = Dom.svg('text');
+		text.textContent = 'test';
+		svg.appendChild(text);
+		document.body.appendChild(svg);
+
+		try {
+			expect(measureTextWidth(text)).toBeGreaterThan(0);
+		} finally {
+			document.body.removeChild(svg);
+		}
+	});
+});

--- a/designer/src/core/measure-text-width.ts
+++ b/designer/src/core/measure-text-width.ts
@@ -1,0 +1,3 @@
+export function measureTextWidth(text: SVGTextElement): number {
+	return text.getBBox().width;
+}

--- a/designer/src/core/simple-event.ts
+++ b/designer/src/core/simple-event.ts
@@ -20,11 +20,6 @@ export class SimpleEvent<T> {
 		}
 	};
 
-	/**
-	 * @deprecated Use `emit` method instead.
-	 */
-	public readonly forward = this.emit;
-
 	public count(): number {
 		return this.listeners.length;
 	}

--- a/designer/src/designer-configuration.ts
+++ b/designer/src/designer-configuration.ts
@@ -94,6 +94,11 @@ export interface DesignerConfiguration<TDefinition extends Definition = Definiti
 	i18n?: I18n;
 
 	/**
+	 * @description Custom text width measurer. By default, the designer uses `getBBox()` method to measure the width of the text.
+	 */
+	textWidthMeasurer?: TextWidthMeasurer;
+
+	/**
 	 * @description Pass the shadow root of the shadow root to the designer if the designer is placed inside the shadow DOM.
 	 */
 	shadowRoot?: ShadowRoot;
@@ -163,6 +168,8 @@ export interface PreferenceStorage {
 	setItem(key: string, value: string): void;
 	getItem(key: string): string | null;
 }
+
+export type TextWidthMeasurer = (text: SVGTextElement) => number;
 
 export interface StepsConfiguration {
 	isSelectable?: (step: Step, parentSequence: Sequence) => boolean;

--- a/designer/src/designer-context.ts
+++ b/designer/src/designer-context.ts
@@ -14,6 +14,7 @@ import { WorkspaceController, WorkspaceControllerWrapper } from './workspace/wor
 import { MemoryPreferenceStorage } from './core/memory-preference-storage';
 import { PlaceholderController } from './workspace/placeholder/placeholder-controller';
 import { Uid } from './core';
+import { measureTextWidth } from './core/measure-text-width';
 
 export class DesignerContext {
 	public static create(
@@ -41,6 +42,7 @@ export class DesignerContext {
 		const definitionWalker = configuration.definitionWalker ?? new DefinitionWalker();
 		const i18n: I18n = configuration.i18n ?? ((_, defaultValue) => defaultValue);
 		const uidGenerator = configuration.uidGenerator ?? Uid.next;
+		const textWidthMeasurer = configuration.textWidthMeasurer ?? measureTextWidth;
 		const stateModifier = StateModifier.create(definitionWalker, uidGenerator, state, configuration.steps);
 		const customActionController = new CustomActionController(configuration, state, stateModifier);
 
@@ -57,6 +59,7 @@ export class DesignerContext {
 			definitionWalker,
 			preferenceStorage,
 			i18n,
+			textWidthMeasurer,
 			services
 		);
 

--- a/designer/src/designer-extension.ts
+++ b/designer/src/designer-extension.ts
@@ -6,7 +6,7 @@ import { ComponentContext } from './component-context';
 import { Vector } from './core';
 import { CustomActionController } from './custom-action-controller';
 import { ComponentType, Definition, Sequence, Step } from './definition';
-import { I18n, PreferenceChange } from './designer-configuration';
+import { I18n, PreferenceChange, TextWidthMeasurer } from './designer-configuration';
 import {
 	Badge,
 	ClickCommand,
@@ -49,6 +49,8 @@ export type StepComponentViewFactory = StepExtension['createComponentView'];
 
 export interface StepComponentViewContext {
 	i18n: I18n;
+	textWidthMeasurer: TextWidthMeasurer;
+
 	getStepName(): string;
 	getStepIconUrl(): string | null;
 	createStepComponent(parentElement: SVGElement, parentSequence: Sequence, step: Step, position: number): StepComponent;

--- a/designer/src/workspace/common-views/label-view.spec.ts
+++ b/designer/src/workspace/common-views/label-view.spec.ts
@@ -1,4 +1,5 @@
 import { Dom } from '../../core/dom';
+import { measureTextWidth } from '../../core/measure-text-width';
 import { LabelView } from './label-view';
 
 describe('LabelView', () => {
@@ -14,7 +15,8 @@ describe('LabelView', () => {
 				radius: 10
 			},
 			'test',
-			'primary'
+			'primary',
+			measureTextWidth
 		);
 		expect(parent.children.length).not.toEqual(0);
 	});

--- a/designer/src/workspace/common-views/label-view.ts
+++ b/designer/src/workspace/common-views/label-view.ts
@@ -1,4 +1,5 @@
 import { Dom } from '../../core/dom';
+import { TextWidthMeasurer } from '../../designer-configuration';
 import { LabelViewConfiguration } from './label-view-configuration';
 
 export class LabelView {
@@ -7,7 +8,8 @@ export class LabelView {
 		y: number,
 		cfg: LabelViewConfiguration,
 		text: string,
-		theme: 'primary' | 'secondary'
+		theme: 'primary' | 'secondary',
+		textWidthMeasurer: TextWidthMeasurer
 	): LabelView {
 		const g = Dom.svg('g', {
 			class: `sqd-label sqd-label-${theme}`
@@ -20,7 +22,8 @@ export class LabelView {
 		});
 		nameText.textContent = text;
 		g.appendChild(nameText);
-		const width = Math.max(nameText.getBBox().width + cfg.paddingX * 2, cfg.minWidth);
+		const nameWidth = textWidthMeasurer(nameText);
+		const width = Math.max(nameWidth + cfg.paddingX * 2, cfg.minWidth);
 
 		const nameRect = Dom.svg('rect', {
 			class: 'sqd-label-rect',

--- a/designer/src/workspace/container-step/container-step-component-view.ts
+++ b/designer/src/workspace/container-step/container-step-component-view.ts
@@ -16,7 +16,7 @@ export const createContainerStepComponentViewFactory =
 		return viewContext.createRegionComponentView(parentElement, COMPONENT_CLASS_NAME, (g, regionViewBuilder) => {
 			const step = stepContext.step;
 			const name = viewContext.getStepName();
-			const labelView = LabelView.create(g, cfg.paddingTop, cfg.label, name, 'primary');
+			const labelView = LabelView.create(g, cfg.paddingTop, cfg.label, name, 'primary', viewContext.textWidthMeasurer);
 			const sequenceComponent = viewContext.createSequenceComponent(g, step.sequence);
 
 			const halfOfWidestElement = labelView.width / 2;

--- a/designer/src/workspace/sequence/default-sequence-component-view.ts
+++ b/designer/src/workspace/sequence/default-sequence-component-view.ts
@@ -20,7 +20,9 @@ export class DefaultSequenceComponentView implements ComponentView {
 		const g = Dom.svg('g');
 		parent.appendChild(g);
 
-		const components: StepComponent[] = [];
+		const components = new Array<StepComponent>(sequence.length);
+		let restWidth = 0;
+		let joinX = 0;
 		for (let index = 0; index < sequence.length; index++) {
 			const stepContext: StepContext = {
 				parentSequence: sequenceContext.sequence,
@@ -31,15 +33,15 @@ export class DefaultSequenceComponentView implements ComponentView {
 				isOutputConnected: index === sequence.length - 1 ? sequenceContext.isOutputConnected : true,
 				isPreview: sequenceContext.isPreview
 			};
-			components[index] = componentContext.stepComponentFactory.create(g, stepContext, componentContext);
+			const component = componentContext.stepComponentFactory.create(g, stepContext, componentContext);
+			components[index] = component;
+
+			restWidth = Math.max(restWidth, component.view.width - component.view.joinX);
+			joinX = Math.max(joinX, component.view.joinX);
 		}
 
-		let joinX: number;
 		let totalWidth: number;
-		if (components.length > 0) {
-			const restWidth = Math.max(...components.map(c => c.view.width - c.view.joinX));
-
-			joinX = Math.max(...components.map(c => c.view.joinX));
+		if (sequence.length > 0) {
 			totalWidth = joinX + restWidth;
 		} else {
 			joinX = phWidth / 2;

--- a/designer/src/workspace/step-component-view-context-factory.ts
+++ b/designer/src/workspace/step-component-view-context-factory.ts
@@ -8,6 +8,8 @@ export class StepComponentViewContextFactory {
 
 		return {
 			i18n: componentContext.i18n,
+			textWidthMeasurer: componentContext.textWidthMeasurer,
+
 			getStepIconUrl: () => componentContext.iconProvider.getIconUrl(stepContext.step),
 			getStepName: () => componentContext.i18n(`step.${stepContext.step.type}.name`, stepContext.step.name),
 			createStepComponent: (parentElement: SVGElement, parentSequence: Sequence, step: Step, position: number) => {

--- a/designer/src/workspace/switch-step/switch-step-component-view.ts
+++ b/designer/src/workspace/switch-step/switch-step-component-view.ts
@@ -77,7 +77,7 @@ export const createSwitchStepComponentViewFactory =
 			const paddingTop = cfg.paddingTop1 + cfg.paddingTop2;
 
 			const name = viewContext.getStepName();
-			const nameLabelView = LabelView.create(g, paddingTop, cfg.nameLabel, name, 'primary');
+			const nameLabelView = LabelView.create(g, paddingTop, cfg.nameLabel, name, 'primary', viewContext.textWidthMeasurer);
 			const branchNames = branchNameResolver ? branchNameResolver(step) : Object.keys(step.branches);
 
 			if (branchNames.length === 0) {
@@ -105,7 +105,14 @@ export const createSwitchStepComponentViewFactory =
 				const translatedLabel = viewContext.i18n(`stepComponent.${step.type}.branchName`, label);
 
 				const labelY = paddingTop + cfg.nameLabel.height + cfg.connectionHeight;
-				const labelView = LabelView.create(g, labelY, cfg.branchNameLabel, translatedLabel, 'secondary');
+				const labelView = LabelView.create(
+					g,
+					labelY,
+					cfg.branchNameLabel,
+					translatedLabel,
+					'secondary',
+					viewContext.textWidthMeasurer
+				);
 
 				const component = viewContext.createSequenceComponent(g, step.branches[branchName]);
 

--- a/designer/src/workspace/task-step/task-step-component-view.ts
+++ b/designer/src/workspace/task-step/task-step-component-view.ts
@@ -27,9 +27,11 @@ export const createTaskStepComponentViewFactory =
 		});
 		text.textContent = viewContext.getStepName();
 		g.appendChild(text);
-		const textWidth = Math.max(text.getBBox().width, cfg.minTextWidth);
 
-		const boxWidth = cfg.iconSize + cfg.paddingLeft + cfg.paddingRight + cfg.textMarginLeft + textWidth;
+		const textWidth = viewContext.textWidthMeasurer(text);
+		const width = Math.max(textWidth, cfg.minTextWidth);
+
+		const boxWidth = cfg.iconSize + cfg.paddingLeft + cfg.paddingRight + cfg.textMarginLeft + width;
 
 		const rect = Dom.svg('rect', {
 			x: 0.5,
@@ -40,7 +42,6 @@ export const createTaskStepComponentViewFactory =
 			rx: cfg.radius,
 			ry: cfg.radius
 		});
-		g.insertBefore(rect, text);
 
 		const iconUrl = viewContext.getStepIconUrl();
 		const icon = iconUrl
@@ -58,6 +59,8 @@ export const createTaskStepComponentViewFactory =
 			width: cfg.iconSize,
 			height: cfg.iconSize
 		});
+
+		g.insertBefore(rect, text);
 		g.appendChild(icon);
 
 		const isInputViewHidden = !stepContext.isInputConnected; // TODO: handle inside the folder

--- a/designer/tsconfig.json
+++ b/designer/tsconfig.json
@@ -10,12 +10,7 @@
 		"declaration": true,
 		"declarationDir": "./build/",
 		"moduleResolution": "node",
-		"lib": [
-			"es2015",
-			"dom"
-		]
+		"lib": ["es2015", "dom"]
 	},
-	"include": [
-		"./src/"
-	]
+	"include": ["./src/"]
 }

--- a/examples/assets/lib.js
+++ b/examples/assets/lib.js
@@ -13,7 +13,7 @@ function embedStylesheet(url) {
 	document.write(`<link href="${url}" rel="stylesheet">`);
 }
 
-const baseUrl = isTestEnv() ? '../designer' : '//cdn.jsdelivr.net/npm/sequential-workflow-designer@0.37.4';
+const baseUrl = isTestEnv() ? '../designer' : '//cdn.jsdelivr.net/npm/sequential-workflow-designer@0.38.0';
 
 embedScript(`${baseUrl}/dist/index.umd.js`);
 embedStylesheet(`${baseUrl}/css/designer.css`);

--- a/examples/assets/stress-test.js
+++ b/examples/assets/stress-test.js
@@ -2,13 +2,29 @@
 
 const uid = sequentialWorkflowDesigner.Uid.next;
 
+// In this example, we are using a custom text width measurer that uses canvas to measure the width of the text.
+// This approach is much faster than the default one, which uses `getBBox`, but the downside is that
+// we need to set the same font that is used in the designer.
+class TextWidthMeasurer {
+	constructor() {
+		this.canvas = document.createElement('canvas');
+		this.context = this.canvas.getContext('2d');
+		this.context.font = '14px "Open Sans", Arial, Verdana, Serif';
+	}
+
+	measure = text => {
+		return this.context.measureText(text.textContent).width;
+	};
+}
+
 class Steps {
 	static createTask() {
+		const n = Math.floor(Math.random() * 10) + 1;
 		return {
 			id: uid(),
 			componentType: 'task',
 			type: 'task',
-			name: 'Stress test',
+			name: 'Str' + 'e'.repeat(n) + 'ss test',
 			properties: {}
 		};
 	}
@@ -37,7 +53,8 @@ const configuration = {
 	},
 	toolbox: false,
 	editors: false,
-	controlBar: true
+	controlBar: true,
+	textWidthMeasurer: new TextWidthMeasurer().measure
 };
 
 const LIMIT = 256;
@@ -87,4 +104,13 @@ const startDefinition = {
 };
 
 const placeholder = document.getElementById('designer');
-sequentialWorkflowDesigner.Designer.create(placeholder, startDefinition, configuration);
+let startTime = Date.now();
+const designer = sequentialWorkflowDesigner.Designer.create(placeholder, startDefinition, configuration);
+designer.onRootComponentUpdated.subscribe(() => {
+	if (startTime === null) {
+		return;
+	}
+	const endTime = Date.now();
+	console.log(`First render time: ${endTime - startTime}ms`);
+	startTime = null;
+});

--- a/react/package.json
+++ b/react/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "sequential-workflow-designer-react",
 	"description": "React wrapper for Sequential Workflow Designer component.",
-	"version": "0.37.4",
+	"version": "0.38.0",
 	"type": "module",
 	"main": "./lib/esm/index.js",
 	"types": "./lib/index.d.ts",
@@ -47,7 +47,7 @@
 	"peerDependencies": {
 		"react": ">=18.2.0",
 		"react-dom": ">=18.2.0",
-		"sequential-workflow-designer": "^0.37.4"
+		"sequential-workflow-designer": "^0.38.0"
 	},
 	"devDependencies": {
 		"@rollup/plugin-node-resolve": "^16.0.1",
@@ -63,7 +63,7 @@
 		"prettier": "^3.2.5",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"sequential-workflow-designer": "^0.37.4",
+		"sequential-workflow-designer": "^0.38.0",
 		"rollup": "^4.40.0",
 		"rollup-plugin-dts": "^6.2.1",
 		"rollup-plugin-typescript2": "^0.36.0",

--- a/react/src/SequentialWorkflowDesignerController.ts
+++ b/react/src/SequentialWorkflowDesignerController.ts
@@ -65,7 +65,7 @@ export class SequentialWorkflowDesignerController {
 			throw new Error('Designer is already set');
 		}
 		this.designer = designer;
-		this.onIsReadyChanged.forward();
+		this.onIsReadyChanged.emit();
 	}
 
 	private getDesigner(): Designer {

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "sequential-workflow-designer-svelte",
 	"description": "Svelte wrapper for Sequential Workflow Designer component.",
-	"version": "0.37.4",
+	"version": "0.38.0",
 	"license": "MIT",
 	"scripts": {
 		"prepare": "cp ../LICENSE LICENSE",
@@ -28,10 +28,10 @@
 	],
 	"peerDependencies": {
 		"svelte": "^4.0.0",
-		"sequential-workflow-designer": "^0.37.4"
+		"sequential-workflow-designer": "^0.38.0"
 	},
 	"devDependencies": {
-		"sequential-workflow-designer": "^0.37.4",
+		"sequential-workflow-designer": "^0.38.0",
 		"@sveltejs/adapter-static": "^2.0.3",
 		"@sveltejs/kit": "^1.20.4",
 		"@sveltejs/package": "^2.0.0",


### PR DESCRIPTION
This version introduces a new configuration property: `textWidthMeasurer`. You can now set a custom function to measure the width of text in the designer. Measuring text width is necessary to calculate the layout of the designer components. By default, the designer uses the `getBBox()` method to measure text width. This method is universal and always works, but unfortunately, it is not the fastest option. You can now provide your own implementation, for example, by using the `CanvasRenderingContext2D.measureText()` method.

Added support for Angular 22.